### PR TITLE
[doc] sendMsg example typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ rocketChatApi.leaveRoom(roomID ,function(err,body){
 ### <a id="send-messages"></a>Sending a message
 
 ```
-rocketChatApi.sendMsg(roomID ,function(err,body){
+rocketChatApi.sendMsg(roomID, message, function(err,body){
 	if(err)
 		console.log(err);
 	else


### PR DESCRIPTION
arguments list error in example code.