### PR TITLE
Added a way to add the version to the base url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ $ npm install
 
 ```
 var RocketChatApi = require('rocketchat').RocketChatApi;
+// alpha-api versions
 var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password);
+// v1-api versions
+var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password, "v1");
 ```
 
 ### Obtaining the running rocket-chat version

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JavaScript RocketChat API for node.js
 
+**Node this is a fork of [qeesung/rocketchat-node](https://github.com/qeesung/rocketchat-node) and supposed to be rejoined as soon as https://github.com/qeesung/rocketchat-node/pull/9 is closed. Please do not rely on this npm package.**
+
 A node.js module, which provides an object oriented wrapper for the RocketChat REST API.
 
 RocketChat official website address can be found [here](https://rocket.chat/)  .
@@ -21,14 +23,14 @@ This Lib library package the following functions:
 Install with the node package manager [npm](http://npmjs.org/):
 
 ```
-$ npm install rocketchat
+$ npm install rocketchat-node
 ```
 
 or
 
 Install via git clone:
 ```
-$ git clone https://github.com/qeesung/rocketchat-node.git
+$ git clone https://github.com/MatthiasKainer/rocketchat-node.git
 $ cd rocketchat-node
 $ npm install
 ```

--- a/lib/rocket-chat.js
+++ b/lib/rocket-chat.js
@@ -33,6 +33,33 @@ var RocketChatApi = function(protocol , host , port , username , password, versi
     this.token = null;
     this.version = version || false;
 
+    var versionRequestData = {
+        "false" : {
+            "sendMsg" : {
+                "path" : function(data) {
+                    return 'rooms/'+data.roomId+"/send";
+                },
+                "body" : function(data) {
+                    return {
+                        msg : data.message
+                    }
+                }
+            }
+        },
+        "v1" : {
+            "sendMsg" : {
+                "path" : function(data) {
+                    return 'chat.postMessage';
+                },
+                "body" : function(data) {
+                    return{
+                        "roomId" : data.roomId,
+                        "text" : data.message
+                    }
+                }
+            }
+        }
+    }
 
     /**
      * make a rest api uri
@@ -50,6 +77,14 @@ var RocketChatApi = function(protocol , host , port , username , password, versi
         });
         return decodeURIComponent(uri);
     };
+
+    this.getRequestData = function(functionName) {
+        if (!versionRequestData[this.version.toString()]) 
+            throw "Version not supported";
+        if (!versionRequestData[this.version.toString()][functionName]) 
+            throw "Method not supported in this version";
+        return versionRequestData[this.version.toString()][functionName];
+    }
 
     /**
      * set the request token header
@@ -377,14 +412,17 @@ var RocketChatApi = function(protocol , host , port , username , password, versi
      * @param callback invoke after sent msg successfully
      */
     this.sendMsg = function(roomId , message , callback){
-        var self = this;
+        var data = { roomId : roomId, message : message };
+        var requestData = this.getRequestData("sendMsg");
+        var uri = this.makeUri(requestData.path(data));
+        var body = requestData.body(data);
         var options = {
-            uri: self.makeUri('rooms/'+roomId+"/send"),
+            uri: uri,
             method: 'POST',
             headers:{
                 'Content-Type': 'application/json'
             },
-            form:{msg:message}
+            form:body
         };
 
         this.doRequest(options, function(error, response, body) {

--- a/lib/rocket-chat.js
+++ b/lib/rocket-chat.js
@@ -24,13 +24,14 @@ var url = require('url'),
  * @param password rocket chat password
  * @constructor
  */
-var RocketChatApi = function(protocol , host , port , username , password){
+var RocketChatApi = function(protocol , host , port , username , password, version){
     this.protocol = protocol || "http";
     this.host = host || "demo.rocket.chat";
     this.port =  port || 80;
     this.username = username;
     this.password = password;
     this.token = null;
+    this.version = version || false;
 
 
     /**
@@ -39,7 +40,7 @@ var RocketChatApi = function(protocol , host , port , username , password){
      * @returns {string} rest api full path , example https://demo.rocket.chat/api/login
      */
     this.makeUri = function(pathname){
-        var basePath = '/api/';
+        var basePath = '/api/' + ((this.version) ? this.version + '/' : '');
 
         var uri = url.format({
             protocol: this.protocol,

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "rocketchat",
+  "name": "rocketchat-node",
   "version": "0.1.0",
   "description": "Rocket chat node api",
   "main": "./lib/rocket-chat.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --grep versionRequestData"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qeesung/rocketchat-node.git"
+    "url": "git+https://github.com/MatthiasKainer/rocketchat-node.git"
   },
   "keywords": [
     "rocket-chat"
   ],
-  "author": "qeesung",
+  "author": "qeesung, matthiaskainer",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/qeesung/rocketchat-node/issues"
+    "url": "https://github.com/MatthiasKainer/rocketchat-node/issues"
   },
-  "homepage": "https://github.com/qeesung/rocketchat-node#readme",
+  "homepage": "https://github.com/MatthiasKainer/rocketchat-node#readme",
   "dependencies": {
     "request": "^2.72.0",
     "url": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocketchat-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Rocket chat node api",
   "main": "./lib/rocket-chat.js",
   "scripts": {

--- a/test/rocket.test.js
+++ b/test/rocket.test.js
@@ -29,6 +29,19 @@ describe("Test the rest api and rocketchat version version",function () {
     });
 });
 
+describe("[multiple-api-versions] test multiple api versions", function() {
+     it("should not add a version for alpha versions of gitlab", function(done) {
+         var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password);
+         rocketChatApi.makeUri("url").should.be.equal("http://192.168.1.102:3000/api/url");
+         done();
+     });
+
+     it("should add a version to the base uri for alpha versions of gitlab", function(done) {
+         var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password, "v1");
+         rocketChatApi.makeUri("url").should.be.equal("http://192.168.1.102:3000/api/v1/url");
+         done();
+     });
+});
 
 describe("test login the logout",function () {
     var rocketChatApi = null;

--- a/test/rocket.test.js
+++ b/test/rocket.test.js
@@ -43,6 +43,80 @@ describe("[multiple-api-versions] test multiple api versions", function() {
      });
 });
 
+describe("[versionRequestData] test single versions", function() {
+    describe("nonexisting version", function() {
+        var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password, "please-never-exist-as-version");
+
+        it("should fail", function(done) {
+            var fail;
+            try {
+                rocketChatApi.getRequestData("sendMsg");
+            } catch (err) {
+                err = fail;
+            }
+
+            should(fail).not.be.null;
+            done();
+        });
+    })
+
+    describe("nonexisting function", function() {
+        var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password);
+
+        it("should fail", function(done) {
+            var fail;
+            try {
+                rocketChatApi.getRequestData("please-never-exist-as-function");
+            } catch (err) {
+                err = fail;
+            }
+
+            should(fail).not.be.null;
+            done();
+        });
+    })
+
+    describe("sendMsg", function () {
+        describe("alpha version", function() {
+            var requestData;
+
+            before(function () {
+                var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password);
+                requestData = rocketChatApi.getRequestData("sendMsg");
+            });
+
+            it("should return the correct path for this version ", function(done) {
+                var roomId = "roomId";
+                should(requestData).not.be.null;
+                requestData.path({ roomId : roomId }).should.be.equal('rooms/'+roomId+"/send");
+                done();
+            });
+        });
+
+        describe("version1", function() {
+            var requestData;
+
+            before(function () {
+                var rocketChatApi = new RocketChatApi('http', config.host, config.port, config.user, config.password, "v1");
+                requestData = rocketChatApi.getRequestData("sendMsg");
+            });
+
+            it("should return the correct path for this version ", function(done) {
+                var roomId = "roomId";
+                var message = "string";
+                var data = { roomId : roomId, message : message };
+                should(requestData).not.be.null;
+                requestData.path(data).should.be.equal('chat.postMessage');
+                requestData.body(data).should.be.eql({
+                    "roomId" : roomId,
+                    "text" : message 
+                });
+                done();
+            });
+        })
+    })
+})
+
 describe("test login the logout",function () {
     var rocketChatApi = null;
     beforeEach(function () {


### PR DESCRIPTION
According to new specs at https://rocket.chat/docs/developer-guides/rest-api/ you need a version in your resource (i.e. v1). This merge request should ensure that the new and the old urls work in parallel

part of resolution for issue #8 