### PR TITLE
Refactored usage of room-changes and added documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This Lib library package the following functions:
   - [Subscriptions](#Subscriptions)
     - [stream-notify-user](#Subscriptions.stream-notify-user)
       - [notification](#Subscriptions.stream-notify-user.notification)
+    - [stream-room-messages](#Subscriptions.stream-room-messages)
 
 
 ## Installation
@@ -2552,12 +2553,15 @@ Methods allow you to invoke methods (i.e. send message) while subscriptions allo
 Subscribe to notification. A notification seems to be a mention in a channel. The result is only a part of the full message, to get attachments one will have to query for the message afterwards.
 
 ```js
+
 this.rocketChatClient.notify.user.onNotification(userId, callback);
+
 ```
 
 Result:
 
 ```json
+
 {
     "msg":"changed",
     "collection":"stream-notify-user",
@@ -2581,8 +2585,33 @@ Result:
         ]
     }
 }
+
 ```
 
+##### <a id="Subscriptions.stream-room-messages"></a> stream-room-messages
+
+Subscribe to new messages in a room.
+
+```js
+
+this.rocketChatClient.notify.room.onChanged(roomId, callback);
+
+```
+
+Result
+
+```json
+
+{
+    "msg":"changed",
+    "collection":"stream-room-messages",
+    "id":"id",
+    "fields":{
+        "eventName":"${roomId}"
+    }
+}
+
+```
 
 ## Options
 

--- a/lib/api/notify.js
+++ b/lib/api/notify.js
@@ -2,6 +2,7 @@ class Notify {
     constructor(client) {
         this.client = client;
         this.user = new (require("./subscription/user"))(client);
+        this.room = new (require("./subscription/room"))(client);
     }
 }
 module.exports = Notify;

--- a/lib/api/subscription/room.js
+++ b/lib/api/subscription/room.js
@@ -1,0 +1,10 @@
+class Room {
+    constructor(client) {
+        this.client = client;
+    }
+
+    onChanged(roomId, onEventPublished) {
+        this.client.subscribe({ stream : "stream-room-messages", event : roomId }, onEventPublished);
+    }
+}
+module.exports = Room;

--- a/lib/api/subscription/user.js
+++ b/lib/api/subscription/user.js
@@ -1,3 +1,5 @@
+const Room = require("./room");
+
 class User {
     constructor(client) {
         this.client = client;

--- a/lib/api/subscription/user.js
+++ b/lib/api/subscription/user.js
@@ -7,8 +7,9 @@ class User {
         this.client.subscribe({ userId, stream : "stream-notify-user", event : "notification" }, onEventPublished);
     }
 
+    /** deprecated in favor if room.onChanged */
     onRoomChanged(roomId, onEventPublished) {
-        this.client.subscribe({ stream : "stream-room-messages", event : roomId }, onEventPublished);
+        new Room(this.client).onChanged(roomId, onEventPublished);
     }
 }
 module.exports = User;

--- a/test/notifyUser.test.js
+++ b/test/notifyUser.test.js
@@ -76,7 +76,7 @@ describe("notifyUser", function () {
             let message = "hello world!";
             this.timeout(5000);
 
-            client.notify.user.onRoomChanged(roomId, function (err, body) {
+            client.notify.room.onChanged(roomId, function (err, body) {
                 should(err).be.null();
                 should(body).not.be.null();
                 should(body.msg).be.equal("changed");


### PR DESCRIPTION
I found that having the `stream-room-messages` on the user seems to be what is intended by rocketchats implementation. Tried to refactor it accordingly. Can you take a look if this makes more sense?
Kept the old way accordingly to not violate the #60 fix on the very next release 