### PR TITLE
Make users.list accept an object as the other list methods

### DIFF
--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -1,13 +1,12 @@
+const pageQueryMapping = require("./lists/pageQueryMapper");
+
 class Users {
     constructor(client){
         this.client = client;
     }
 
-    list (offset, count, callback) {
-        if (arguments.length === 1)
-            return this.client.request("GET", "users.list", null, offset);
-        else if (arguments.length === 3)
-            return this.client.request("GET", "users.list", { offset : offset, count : count }, callback);
+    list ({ offset = 0, count = 0, sort = undefined, fields = undefined, query = undefined}, callback) {
+        return this.client.request("GET", "users.list", pageQueryMapping(arguments[0]), callback);
     }
 
     create (user, callback) {


### PR DESCRIPTION
Currently I'm unable to pass the `query` parameter to `Users.list()` when searching for a user by nickname.