### PR TITLE
Update rocketChat.js

### DIFF
--- a/lib/rocketChat.js
+++ b/lib/rocketChat.js
@@ -2,7 +2,8 @@ var net = require("./net");
 
 function RocketChatClient(protocol, host, port, username, password, onConnected) {
     let basepath = "";
-        
+    let useragent = "";
+
     if (arguments.length === 1) {
         host = arguments[0].host || "localhost";
         port = arguments[0].port || 3000;
@@ -10,12 +11,17 @@ function RocketChatClient(protocol, host, port, username, password, onConnected)
         password = arguments[0].password || "";
         onConnected = arguments[0].onConnected;
         basepath = (arguments[0].basepath || "").replace(/^\/+|\/+$/g, "");
+        useragent = arguments[0].useragent || "";
         protocol = arguments[0].protocol || "http";
     }
-    
+
     onConnected = onConnected || function() {};
     var restClient = new net.RestClient(protocol, host, port, basepath + "/api/v1/");
-    var wsClient = new net.WsClient("ws", host, port, basepath + "/websocket");
+    var wsClient = new net.WsClient((protocol === "http") ? "ws" : "wss", host, port, basepath + "/websocket");
+
+    if (useragent) {
+      restClient.setHeader("User-Agent", useragent);
+    }
 
     this.authentication = new (require("./api/authentication"))(restClient);
 


### PR DESCRIPTION
The optional "useragent" parameter has been added to the connection parameters. In my network, Cisco ChekPoint requires its presence in requests.
Added method selection (ws/wss) for net.wsClient depending on the specified protocol (http/https) in the connection parameters. There was a websocket error with ssl requests on port 443.